### PR TITLE
Use audio hal - audio.parimary.msm7627a.so and audio_policy.msm7627a.so from binary blobs.

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -205,6 +205,8 @@ COMMON_HW="
 	sensors.m4.so
 	camera.msm7627a.so
 	gps.default.so
+	audio_policy.msm7627a.so
+	audio.primary.msm7627a.so
 	"
 
 copy_files "$COMMON_HW" "system/lib/hw" "hw"


### PR DESCRIPTION
Customization from manufacturer are on audio hal so we need to use them.  
